### PR TITLE
Add styling to navbar for smaller screens, dropdown menu

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -79,7 +79,7 @@ body {
         line-height: 100px;
     }
 }
-#congraluations{
+#congratulations{
     position: absolute;
     top:8%;
     width :100%;

--- a/css/main.css
+++ b/css/main.css
@@ -142,6 +142,11 @@ body {
     width: 100%;
 }
 
+.navigator-bar .nav-menu .nav-pills .nav-item {
+    margin-left: 0.3rem;
+    margin-right: 0.3rem;
+}
+
 .navigator-bar .nav-menu .nav-pills .nav-item:last-child {
     margin-left: auto;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -6,7 +6,7 @@
 body {
     margin-top: 0px;
     background-color: #e9ecef;
-    padding-top: 150px;
+    font-family: 'Noto Sans', sans-serif;
 }
 .card-body{
     background-color: #e9ecef;
@@ -116,6 +116,59 @@ body {
 
 .navigator-bar {
     background-color: var(--primary);
+    padding-bottom: 0.4rem;
+    margin-bottom: 1rem;
+}
+
+.navigator-bar h1 {
+    font-size: 2.0rem;
+    padding: 0 1rem 0 0;
+    margin-right: 12%;
+}
+
+.navigator-bar .nav-menu {
+    justify-content: center;
+}
+
+.navigator-bar .nav-item {
+    transition: background 0.2s ease-in;
+}
+.navigator-bar .nav-item:hover {
+    background-color: var(--secondary);
+    border-radius: 5px;
+}
+
+.navigator-bar .nav-menu .nav-pills {
+    width: 100%;
+}
+
+.navigator-bar .nav-menu .nav-pills .nav-item:last-child {
+    margin-left: auto;
+}
+
+#github-link:hover {
+    background-color: rgb(212, 87, 87);
+    border-radius: 5px;
+}
+
+.navigator-bar .navbar-toggler {
+    margin-top: 0.1rem;
+    margin-bottom: 1rem;
+}
+
+.navigator-bar .external a {
+    color: black;
+}
+
+@media screen and (max-width: 576px) {
+    .navigator-bar .nav-menu .nav-pills, .nav-link, a {
+        width: 100%;
+        display: inline;
+    }
+
+    .navigator-bar .nav-menu .nav-pills .active {
+        width: 100%;
+    }
 }
 
 /** Network */
@@ -126,7 +179,7 @@ body {
 }
 
 #mynetwork {
-    background-color: var(--secondary);
+    background-color: rgb(85, 160, 167);
     height: 1000px;
     width: 75%;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -116,18 +116,21 @@ body {
 
 .navigator-bar {
     background-color: var(--primary);
-    padding-bottom: 0.4rem;
+    padding-bottom: 0.2rem;
+    padding-top: 0.2rem;
     margin-bottom: 1rem;
 }
 
 .navigator-bar h1 {
-    font-size: 2.0rem;
+    font-size: 2.1rem;
     padding: 0 1rem 0 0;
     margin-right: 12%;
+    line-height: 1.5;
 }
 
 .navigator-bar .nav-menu {
     justify-content: center;
+    margin-left: 0;
 }
 
 .navigator-bar .nav-item {

--- a/css/main.css
+++ b/css/main.css
@@ -1,7 +1,12 @@
+:root {
+    --primary: rgb(85, 160, 167);
+    --secondary: rgb(201, 135, 110);
+}
+
 body {
     margin-top: 0px;
     background-color: #e9ecef;
-    padding-top: 76px;
+    padding-top: 150px;
 }
 .card-body{
     background-color: #e9ecef;
@@ -107,54 +112,11 @@ body {
     }
 }
 
-/* Navbar */
+/* Custom navbar settings */
+
 .navigator-bar {
-    background-color: rgb(97, 96, 96);
-    font-size: 1.6rem;
-    padding-top: 0.5rem;
-    padding-bottom: 0.7rem;
+    background-color: var(--primary);
 }
-
-.navigator-bar h1 {
-    color: white;
-}
-
-.navigator-bar a {
-    color: black;
-}
-
-.navigator-bar .container-contents {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-}
-
-.navigator-bar .container-contents .nav {
-    display: flex;
-    justify-self: center;
-    align-items: center;
-    justify-content: center;
-}
-
-.navigator-bar .container-contents .nav .nav-item {
-    padding-left: 0.1rem;
-    padding-right: 0.1rem;
-}
-
-.navigator-bar .container-contents .external {
-    display: flex;
-    justify-self: flex-end;
-    align-items: center;
-    justify-content: center;
-}
-
-.navigator-bar .container-contents .active {
-    background-color: rgb(49, 164, 218);
-}
-
-.navigator-bar .container-contents .nav-link:hover {
-    background-color: rgb(12, 129, 184);
-}
-
 
 /** Network */
 .network-display {
@@ -164,7 +126,7 @@ body {
 }
 
 #mynetwork {
-    background-color: rgb(196, 235, 235);
+    background-color: var(--secondary);
     height: 1000px;
     width: 75%;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -158,6 +158,11 @@ body {
     margin-left: auto;
 }
 
+#github-link a {
+    color: black;
+    text-decoration: none;
+}
+
 #github-link:hover {
     background-color: rgb(212, 87, 87);
     border-radius: 5px;

--- a/css/main.css
+++ b/css/main.css
@@ -147,6 +147,10 @@ body {
     margin-right: 0.3rem;
 }
 
+.navigator-bar .nav-menu .nav-pills .nav-item .active {
+    background-color: var(--secondary);
+}
+
 .navigator-bar .nav-menu .nav-pills .nav-item:last-child {
     margin-left: auto;
 }
@@ -176,6 +180,15 @@ body {
     }
 }
 
+/** Tab1 */
+#simul .panel-heading {
+    padding-bottom: 1rem;
+    font-size: 1.1rem;
+    line-height: 2;
+    display: flex;
+    justify-content: center;
+}
+
 /** Network */
 .network-display {
     display: flex;
@@ -184,7 +197,21 @@ body {
 }
 
 #mynetwork {
-    background-color: rgb(85, 160, 167);
+    background-color: var(--primary);
     height: 1000px;
     width: 75%;
+}
+
+/** Buttons */
+
+#btn-slot {
+    background-color: var(--secondary);
+}
+
+#btn-double {
+    background-color: var(--secondary);
+}
+
+#btn-amount {
+    background-color: var(--secondary);
 }

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
                             <button class="nav-link" id="probVis-tab" data-bs-toggle="pill" data-bs-target="#probVis" type="button" aria-controls="probVis" aria-selected="false">Visualizer</button>
                         </li>
                         <li class="nav-item" id="github-link">
-                            <button class="nav-link" href="https://github.com/Aearsears/marvel_machine_sim">Github</button>
+                            <button class="nav-link"><a href="https://github.com/Aearsears/marvel_machine_sim">Github</a></button>
                         </li>
                     </ul>
                 </div>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="google-site-verification" content="d58Et_hG0KrLc6xKv03J8U5NA6jqak0kCFxBaz7Y1MM" />
     <link rel="icon" href="img/mm_overlay.png">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap" rel="stylesheet"> 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6" crossorigin="anonymous">
     <link rel="stylesheet" href="css/main.css">
 </head>
@@ -17,7 +18,7 @@
     <section class="navigator">
 
         <!-- custom styling should go in '.navigator-bar' for this -->
-        <nav class="navbar navbar-expand-lg navbar-dark container-fluid fixed-top navigator-bar">
+        <nav class="navbar navbar-expand-lg navbar-dark container-fluid navigator-bar">
             <div class="container-fluid">
                 <h1>Marvel Machine Simulator</h1>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#dropdown" aria-controls="dropdown" aria-expanded="false" aria-label="Toggle dropdown">
@@ -26,26 +27,19 @@
 
                 <!-- items to show on the dropdown menu when the size gets too small 
                     by default the button is not shown and no collapse is displayed when the width is large enough-->
-                <div class="collapse navbar-collapse" id="dropdown">
-                    <div class="internal"> <!-- navigate through the site -->
-                        <ul class="nav nav-pills" id="pills-tab">
-                            <li class="nav-item">
-                                <button class="nav-link active" id="simul-tab" data-bs-toggle="pill" data-bs-target="#simul" type="button" aria-controls="simul" aria-selected="true">Simulator</button>
-                            </li>
-                            <li class="nav-item">
-                                <button class="nav-link" id="probVis-tab" data-bs-toggle="pill" data-bs-target="#probVis" type="button" aria-controls="probVis" aria-selected="false">Visualizer</button>
-                            </li>
-                        </ul>
-                    </div>
-                    <div class="external"> <!-- links to external sites -->
-                        <ul class="nav nav-pills">
-                            <li class="nav-item">
-                                <a class="nav-link" href="https://github.com/Aearsears/marvel_machine_sim">Github</a>
-                            </li>
-                        </ul>
-                    </div>
+                <div class="collapse navbar-collapse nav-menu" id="dropdown">
+                    <ul class="nav nav-pills" id="pills-tab">
+                        <li class="nav-item">
+                            <button class="nav-link active" id="simul-tab" data-bs-toggle="pill" data-bs-target="#simul" type="button" aria-controls="simul" aria-selected="true">Simulator</button>
+                        </li>
+                        <li class="nav-item">
+                            <button class="nav-link" id="probVis-tab" data-bs-toggle="pill" data-bs-target="#probVis" type="button" aria-controls="probVis" aria-selected="false">Visualizer</button>
+                        </li>
+                        <li class="nav-item" id="github-link">
+                            <button class="nav-link" href="https://github.com/Aearsears/marvel_machine_sim">Github</button>
+                        </li>
+                    </ul>
                 </div>
-
             </div>
         </nav>
 

--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
                 <div class="panel panel-primary">
                     <div class="panel-heading">Test your luck and wallet at the Marvel Machine! Dreams and money down the drain, another day for great pain!</div>
                     <div class="panel-body">
-                        <div class="card-body" id = "congraluations">
-                            <h5 class="card-title text-center" id="rainbow-text">Congraluations!</h5>
+                        <div class="card-body" id = "congratulations">
+                            <h5 class="card-title text-center" id="rainbow-text">congratulations!</h5>
                         </div>
                         <div class="slotwrapper" id="slot">
                             <ul id="left">

--- a/index.html
+++ b/index.html
@@ -16,34 +16,46 @@
     <!-- nav -->
     <section class="navigator">
 
-        <nav class="container-fluid navigator-bar fixed-top">
-            <div class="container-contents">
+        <!-- custom styling should go in '.navigator-bar' for this -->
+        <nav class="navbar navbar-expand-lg navbar-dark container-fluid fixed-top navigator-bar">
+            <div class="container-fluid">
                 <h1>Marvel Machine Simulator</h1>
-                <div class="internal">
-                    <ul class="nav nav-pills" id="pills-tab">
-                        <li class="nav-item">
-                            <button class="nav-link active" id="simul-tab" data-bs-toggle="pill" data-bs-target="#simul" type="button" aria-controls="simul" aria-selected="true">Simulator</button>
-                        </li>
-                        <li class="nav-item">
-                            <button class="nav-link" id="probVis-tab" data-bs-toggle="pill" data-bs-target="#probVis" type="button" aria-controls="probVis" aria-selected="false">Visualizer</button>
-                        </li>
-                    </ul>
+                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#dropdown" aria-controls="dropdown" aria-expanded="false" aria-label="Toggle dropdown">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+
+                <!-- items to show on the dropdown menu when the size gets too small 
+                    by default the button is not shown and no collapse is displayed when the width is large enough-->
+                <div class="collapse navbar-collapse" id="dropdown">
+                    <div class="internal"> <!-- navigate through the site -->
+                        <ul class="nav nav-pills" id="pills-tab">
+                            <li class="nav-item">
+                                <button class="nav-link active" id="simul-tab" data-bs-toggle="pill" data-bs-target="#simul" type="button" aria-controls="simul" aria-selected="true">Simulator</button>
+                            </li>
+                            <li class="nav-item">
+                                <button class="nav-link" id="probVis-tab" data-bs-toggle="pill" data-bs-target="#probVis" type="button" aria-controls="probVis" aria-selected="false">Visualizer</button>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="external"> <!-- links to external sites -->
+                        <ul class="nav nav-pills">
+                            <li class="nav-item">
+                                <a class="nav-link" href="https://github.com/Aearsears/marvel_machine_sim">Github</a>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
-                <div class="external">
-                    <ul class="nav nav-pills">
-                        <li class="nav-item">
-                            <a class="nav-link" href="https://github.com/Aearsears/marvel_machine_sim">Github</a>
-                        </li>
-                    </ul>
-                </div>
+
             </div>
         </nav>
 
     </section>
+    <!-- nav end-->
+
 
 
     <!-- content -->
-    <section class="tab-content">
+    <section class="tab-content container-fluid">
         <!-- tab1 -->
         <div class="tab-pane show active" id="simul">
             <div class="container-fluid">

--- a/index.html
+++ b/index.html
@@ -25,9 +25,10 @@
                     <span class="navbar-toggler-icon"></span>
                 </button>
 
-                <!-- items to show on the dropdown menu when the size gets too small 
-                    by default the button is not shown and no collapse is displayed when the width is large enough-->
-                <div class="collapse navbar-collapse nav-menu" id="dropdown">
+                <!-- default: the button is not shown and no collapse is displayed when the width is large enough-->
+                <div class="navbar-collapse nav-menu" id="dropdown"> <!-- adding class ".collapse" to this div will cause a bug where the visualizer
+                    does not automatically open the second menu after selecting a wheel
+                    if other problems happen because of the dependency on collapse class, put it back -->
                     <ul class="nav nav-pills" id="pills-tab">
                         <li class="nav-item">
                             <button class="nav-link active" id="simul-tab" data-bs-toggle="pill" data-bs-target="#simul" type="button" aria-controls="simul" aria-selected="true">Simulator</button>
@@ -43,7 +44,7 @@
             </div>
         </nav>
 
-    </section>
+    </section> 
     <!-- nav end-->
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,10 @@ $('#btn-slot').click(function () {
             //test(); // display the congraluations banner
             $('#congraluations')[0].setAttribute("style","visibility:visible"); 
             sound.pause(); // To stop the looping sound is pause it
+
+            setTimeout(function() {
+                $('#congraluations')[0].setAttribute("style", "visibility:hidden");
+            }, 3000);
         }
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,8 +20,8 @@ sound.addEventListener('ended', function () {
 
 $('#btn-slot').click(function () {
     if ($('#slot ul').is(":animated")) return;
-    if($('#congraluations').is(":visible")){
-        $('#congraluations')[0].setAttribute("style","visibility:hidden");
+    if($('#congratulations').is(":visible")){
+        $('#congratulations')[0].setAttribute("style","visibility:hidden");
     }
     if(indexes!=null){
             //add the items to the inventory
@@ -67,12 +67,12 @@ $('#btn-slot').click(function () {
             ding.play(); // Play ding after each number is stopped
         },
         onFinish: function () {
-            //test(); // display the congraluations banner
-            $('#congraluations')[0].setAttribute("style","visibility:visible"); 
+            //test(); // display the congratulations banner
+            $('#congratulations')[0].setAttribute("style","visibility:visible"); 
             sound.pause(); // To stop the looping sound is pause it
 
             setTimeout(function() {
-                $('#congraluations')[0].setAttribute("style", "visibility:hidden");
+                $('#congratulations')[0].setAttribute("style", "visibility:hidden");
             }, 3000);
         }
     });


### PR DESCRIPTION
- Adds the original navbar-collapse element back to the navigation bar. The button to the github (an external link) is set off to the side and colored differently on hover to show that it would lead to another website and not to another tab of the marvel machine sim.

- On smaller width screens, a dropdown menu appears and on even smaller screens (mobile) the link buttons are set to the width the screen.

- Removed fixed-top for the navbar

- color scheme changed to use complementary colors (could pick better ones later)

- resolves #2 

### Issues
- The accordion body for Items on the tab2 will not automatically open after selecting a wheel sometimes. I removed class ".collapse" from the navbar and it seemed to fix it for some reason(?), but the bug might still be there as I don't know what caused it